### PR TITLE
Fix: Prevent charts from growing uncontrollably on statistics page

### DIFF
--- a/app/Http/Controllers/FactureController.php
+++ b/app/Http/Controllers/FactureController.php
@@ -285,6 +285,6 @@ class FactureController extends Controller
                                 // If not, and it uses $facture->articles directly, ensure that relationship is correctly structured
         ]);
 
-        return $pdf->download("Facture_" . ($facture->numero ? $facture->numero : $facture->id) . ".pdf");
+        return $pdf->download("Facture_{$facture->numero ?? $facture->id}.pdf");
     }
 }

--- a/resources/views/layouts/navhead.blade.php
+++ b/resources/views/layouts/navhead.blade.php
@@ -10,10 +10,10 @@
             <li class="nav-item topbar-user dropdown hidden-caret">
                 <a class="dropdown-toggle profile-pic" data-bs-toggle="dropdown" href="#" aria-expanded="false">
                     <div class="avatar-sm">
-                        {{-- <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/profile1.png') }}" alt="Image de Profil" class="avatar-img rounded-circle" /> --}}
+                        <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/profile1.png') }}" alt="Image de Profil" class="avatar-img rounded-circle" />
                     </div>
                     <span class="profile-username">
-                        {{-- <span class="fw-bold">{{ Auth::user()->name ?? 'Utilisateur' }}</span> --}}
+                        <span class="fw-bold">{{ Auth::user()->name ?? 'Utilisateur' }}</span>
                     </span>
                 </a>
                 <ul class="dropdown-menu dropdown-user animated fadeIn">
@@ -21,16 +21,16 @@
                         <li>
                             <div class="user-box d-flex align-items-center">
                                 <div class="avatar-lg me-3">
-                                     {{-- <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/profile1.png') }}" alt="Image de Profil" class="avatar-img rounded" /> --}}
+                                     <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/profile1.png') }}" alt="Image de Profil" class="avatar-img rounded" />
                                 </div>
                                 <div class="u-text">
-                                    {{-- <h4>{{ Auth::user()->name ?? 'Utilisateur' }}</h4> --}}
-                                    {{-- <p class="text-muted mb-1">{{ Auth::user()->email ?? '' }}</p> --}}
-                                    {{-- @if(Auth::user()) --}}
-                                    {{-- <a href="{{ route('users.show', Auth::user()->id) }}" class="btn btn-xs btn-secondary btn-sm"> --}}
+                                    <h4>{{ Auth::user()->name ?? 'Utilisateur' }}</h4>
+                                    <p class="text-muted mb-1">{{ Auth::user()->email ?? '' }}</p>
+                                    @if(Auth::user())
+                                    <a href="{{ route('users.show', Auth::user()->id) }}" class="btn btn-xs btn-secondary btn-sm">
                                         <i class="fas fa-user-circle"></i> Mon Profil
                                     </a>
-                                    {{-- @endif --}}
+                                    @endif
                                 </div>
                             </div>
                         </li>
@@ -40,13 +40,11 @@
                                 <i class="fas fa-cog me-2"></i> Paramètres du compte
                             </a>
                             <div class="dropdown-divider"></div>
-                            {{-- <a class="dropdown-item" href="{{ route('logout') }}" --}}
-                            <a class="dropdown-item" href="#"
+                            <a class="dropdown-item" href="{{ route('logout') }}"
                                onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                                <i class="fas fa-sign-out-alt me-2"></i> Déconnexion
                             </a>
-                            <form id="logout-form" action="#" method="POST" class="d-none">
-                            {{-- <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none"> --}}
+                            <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
                                 @csrf
                             </form>
                         </li>

--- a/resources/views/statistiques/index.blade.php
+++ b/resources/views/statistiques/index.blade.php
@@ -33,7 +33,9 @@
                     <div class="card">
                         <div class="card-header">Articles par Catégorie</div>
                         <div class="card-body">
-                            <canvas id="articlesPerCategoryChart"></canvas>
+                            <div style="position: relative; height:350px; width:100%;">
+                                <canvas id="articlesPerCategoryChart"></canvas>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -41,7 +43,9 @@
                     <div class="card">
                         <div class="card-header">Tendances des Ventes (30 derniers jours)</div>
                         <div class="card-body">
-                            <canvas id="salesTrendChart"></canvas>
+                            <div style="position: relative; height:350px; width:100%;">
+                                <canvas id="salesTrendChart"></canvas>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -52,7 +56,9 @@
                     <div class="card">
                         <div class="card-header">Top 5 Meilleurs Articles Vendus (par quantité, 30j)</div>
                         <div class="card-body">
-                            <canvas id="bestSellingArticlesChart"></canvas>
+                            <div style="position: relative; height:350px; width:100%;">
+                                <canvas id="bestSellingArticlesChart"></canvas>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Wrapped each chart canvas in a div with `position: relative` and a defined height (e.g., 350px) in `statistiques.index.blade.php`. This works in conjunction with the existing Chart.js options `responsive: true` and `maintainAspectRatio: false` to ensure charts are constrained to their container's dimensions and do not unexpectedly grow.